### PR TITLE
RISC-V: updated image for RVV 0.7.1 to use 2.8.0 toolchain

### DIFF
--- a/ubuntu-github-actions-riscv--22.04/Dockerfile-071
+++ b/ubuntu-github-actions-riscv--22.04/Dockerfile-071
@@ -1,14 +1,56 @@
-# Version: 20231030
+# Version: 20240117
 # Image name: quay.io/opencv-ci/opencv-ubuntu-22.04-riscv-071
 
-FROM ubuntu:22.04 AS dl_base
+FROM ubuntu:22.04 AS builder
 
-ARG TOOLCHAIN_ARC=riscv64-linux-x86_64-20210618.tar.gz
-ADD https://dl.opencv.org/toolchains/${TOOLCHAIN_ARC} /opt/
-RUN cd /opt && tar -xf ${TOOLCHAIN_ARC} && rm -f ${TOOLCHAIN_ARC}
+ARG TOOLCHAIN_BRANCH=xuantie-gnu-toolchain
+ARG TOOLCHAIN_COMMIT=7b294fcd5dbb6b8c2966941146a6b89ef0b5d3a1 # 2.8.0 + fix
+
+RUN apt update && apt install -y \
+    cmake \
+    ccache \
+    ninja-build \
+    git \
+    autoconf \
+    automake \
+    autotools-dev \
+    curl \
+    python3 \
+    python3-pip \
+    libmpc-dev \
+    libmpfr-dev \
+    libgmp-dev \
+    gawk \
+    build-essential \
+    bison \
+    flex \
+    texinfo \
+    gperf \
+    libtool \
+    patchutils \
+    bc \
+    zlib1g-dev \
+    libexpat-dev \
+    libglib2.0-dev
+
+RUN git clone \
+      -b ${TOOLCHAIN_BRANCH} \
+      --recurse-submodules \
+      --shallow-submodules \
+      https://github.com/T-head-Semi/xuantie-gnu-toolchain.git
+
+WORKDIR xuantie-gnu-toolchain
+
+RUN git checkout ${TOOLCHAIN_COMMIT} --recurse-submodules
+
+RUN ./configure --enable-linux --prefix=/opt/riscv
+RUN make -j8 linux
+RUN make -j8 build-qemu
+
+#====================================================================
 
 FROM ubuntu:22.04
-COPY --from=dl_base /opt/riscv64-linux-x86_64 /opt/riscv
+COPY --from=builder /opt/riscv /opt/riscv
 
 ENV PATH=/opt/riscv/bin:${PATH}
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Preparation to switch weekly build to 2.8.0 Xuantie toolchain. Related PR: https://github.com/opencv/opencv/pull/24841

Published: `quay.io/opencv-ci/opencv-ubuntu-22.04-riscv-071:20240117`