### PR TITLE
RISC-V: fixed missing packages

### DIFF
--- a/ubuntu-github-actions-riscv--22.04/Dockerfile-071
+++ b/ubuntu-github-actions-riscv--22.04/Dockerfile-071
@@ -60,7 +60,8 @@ RUN apt update && apt install -y \
     cmake \
     ccache \
     ninja-build \
-    python3
+    python3 \
+    rsync
 
 RUN \
   add-apt-repository ppa:git-core/ppa && \


### PR DESCRIPTION
`rsync` was missing from the image. New image has been rebuilt and uploaded, tests run successfully: https://github.com/opencv/ci-gha-workflow/pull/136