### PR TITLE
RISC-V: added rsync to image

### DIFF
--- a/ubuntu-github-actions-riscv--22.04/Dockerfile-main
+++ b/ubuntu-github-actions-riscv--22.04/Dockerfile-main
@@ -1,4 +1,4 @@
-# Version: 20230910
+# Version: 20240329
 # Image name: quay.io/opencv-ci/opencv-ubuntu-22.04-riscv-main
 
 # 1. LLVM toolchain
@@ -113,6 +113,7 @@ RUN \
     mc \
     nano \
     time \
+    rsync \
     file
 
 RUN \


### PR DESCRIPTION
Updated image for nightly testing for opencv/ci-gha-workflow#165